### PR TITLE
Fixing datasource issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm start
 ### Option 2: Running the container
 
 ```bash
-docker run -p 3000:3000 odrodrig/guestbook-nodejs:latest
+docker run -p 3000:3000 odrodrig/guestbook-nodejs:key-value
 ```
 
 The application can be accessed through http://localhost:3000/
@@ -46,14 +46,25 @@ You must also change the datasource listed in `src/server/model-config.json` to 
     }
   ```
 
-If you would like to change back to the in-memory datasource, edit the datasource under the `list` model in `src/server/model-config.json` to `in-memory` as seen below:
+
+Next, you will need to replace the `src/server/datasources.json` file with the following:
 
 ```json
-  "list": {
-      "dataSource": "in-memory",
-      "public": true
-    }
+{
+  "in-memory": {
+    "name": "in-memory",
+    "connector": "kv-memory"
+  },
+  "redis": {
+    "host": "${REDIS_HOST}",
+    "port": "${REDIS_PORT}",
+    "url": "",
+    "password": "${REDIS_PASS}",
+    "name": "redis",
+    "db": "${REDIS_DB}",
+    "connector": "kv-redis"
   }
+}
 ```
 
 ### Generate from OpenAPI

--- a/src/server/datasources.json
+++ b/src/server/datasources.json
@@ -2,14 +2,5 @@
   "in-memory": {
     "name": "in-memory",
     "connector": "kv-memory"
-  },
-  "redis": {
-    "host": "${REDIS_HOST}",
-    "port": "${REDIS_PORT}",
-    "url": "",
-    "password": "${REDIS_PASS}",
-    "name": "redis",
-    "db": "${REDIS_DB}",
-    "connector": "kv-redis"
   }
 }


### PR DESCRIPTION
The app will fail if there is an unreachable datasource in datasource.json as loopback attempts to connect to the datasource when the application starts. This means that if you defined a Redis instance in datasource.json without it actually being available, then the app would fail right away.

I've removed the redis datasource from datasource.json and added instructions in the readme to add the datasource once you have one available.