### PR TITLE
Fixed datasource issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm start
 ### Option 2: Running the container
 
 ```bash
-docker run -p 3000:3000 odrodrig/guestbook-nodejs:latest
+docker run -p 3000:3000 -d odrodrig/guestbook-nodejs:latest
 ```
 
 The application can be accessed through http://localhost:3000/
@@ -29,8 +29,8 @@ This application has a PersistedModel representation for the data model which is
 
 Required:
 
-- MONGO_HOST - The hostname to access Redis
-- MONGO_PORT - The port to access Redis
+- MONGO_HOST - The hostname to access Mongo
+- MONGO_PORT - The port to access Mongo
 
 Optional:
 
@@ -47,14 +47,28 @@ You must also change the datasource listed in `src/server/model-config.json` to 
     }
   ```
 
-If you would like to change back to the in-memory datasource, edit the datasource under the `entry` model in `src/server/model-config.json` to `in-memory` as seen below:
+Next, you will need to replace the src/server/datasources.json file with the following:
 
 ```json
-  "entry": {
-      "dataSource": "in-memory",
-      "public": true
-    }
+{
+  "in-memory": {
+    "name": "in-memory",
+    "localStorage": "",
+    "file": "",
+    "connector": "memory"
+  },
+  "mongo": {
+    "host": "${MONGO_HOST}",
+    "port": "${MONGO_PORT}",
+    "url": "",
+    "database": "${MONGO_DB}",
+    "password": "${MONGO_PASS}",
+    "name": "mongo",
+    "user": "${MONGO_USER}",
+    "useNewUrlParser": true,
+    "connector": "mongodb"
   }
+}
 ```
 
 ### Data Model

--- a/src/server/datasources.json
+++ b/src/server/datasources.json
@@ -4,16 +4,5 @@
     "localStorage": "",
     "file": "",
     "connector": "memory"
-  },
-  "mongo": {
-    "host": "${MONGO_HOST}",
-    "port": "${MONGO_PORT}",
-    "url": "",
-    "database": "${MONGO_DB}",
-    "password": "${MONGO_PASS}",
-    "name": "mongo",
-    "user": "${MONGO_USER}",
-    "useNewUrlParser": true,
-    "connector": "mongodb"
   }
 }


### PR DESCRIPTION
The app will fail if there is an unreachable datasource in datasource.json as loopback attempts to connect to the datasource when the application starts. This means that if you defined a Mongo instance in datasource.json without it actually being available, then the app would fail right away.

I've removed the Mongo datasource from datasource.json and added instructions in the readme to add the datasource once you have one available.